### PR TITLE
Feature signmeta

### DIFF
--- a/s3curl.pl
+++ b/s3curl.pl
@@ -206,7 +206,7 @@ for (my $i=0; $i<@ARGV; $i++) {
         if ( ! $sm ) {
             push (@resources, "query");
         }
-        for my $attribute (@resources) {
+        for my $attribute (sort @resources) {
             if ($query =~ /(?:^|&)($attribute(?:=[^&]*)?)(?:&|$)/) {
                 push @attributes, uri_unescape($1);
             }

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -203,7 +203,7 @@ for (my $i=0; $i<@ARGV; $i++) {
         my @attributes = ();
         #if the -sm command line option was used then this is probably a search metadata query
         #and the query=xxx needs to be signed in ECS v3.0
-        if ($sm) {
+        if ( ! $sm ) {
             push (@resources, "query");
         }
         for my $attribute (@resources) {
@@ -212,13 +212,12 @@ for (my $i=0; $i<@ARGV; $i++) {
             }
         }
         if (@attributes) {
-            debug("JMC there are attributes");
+            debug("there are attributes");
             $resource .= "?" . join("&", @attributes);
-            debug("JMC resource in attributes = $resource");
+            debug("resource in attributes = $resource");
         }
         # handle virtual hosted requests
         getResourceToSign($host, \$resource);
-        debug("JMC1 resource = $resource");
     }
     elsif ($arg =~ /\-X/) {
         # mainly for DELETE
@@ -242,7 +241,6 @@ for (my $i=0; $i<@ARGV; $i++) {
     }
 }
 
-debug("JMC2 resource = $resource");
 die "Couldn't find resource by digging through your curl command line args!"
     unless defined $resource;
 
@@ -256,13 +254,13 @@ foreach (sort (keys %xamzHeaders)) {
 my $httpDate = (defined $xamzHeaders{'x-amz-date'}) ? '' : POSIX::strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime);
 my $stringToSign = "$method\n$contentMD5\n$contentType\n$httpDate\n$xamzHeadersToSign$resource";
 
-debug("JMC method = $method");
-debug("JMC contentMD5 = $contentMD5");
-debug("JMC contentType = $contentType");
-debug("JMC httpDate = $httpDate");
-debug("JMC xamzHeadersToSign = $xamzHeadersToSign");
-debug("JMC resource = $resource");
-debug("JMC ");
+debug("method = $method");
+debug("contentMD5 = $contentMD5");
+debug("contentType = $contentType");
+debug("httpDate = $httpDate");
+debug("xamzHeadersToSign = $xamzHeadersToSign");
+debug("resource = $resource");
+debug(" ");
 
 debug("StringToSign='" . $stringToSign . "'");
 my $hmac = Digest::HMAC_SHA1->new($secretKey);
@@ -313,9 +311,7 @@ sub debug {
 
 sub getResourceToSign {
     my ($host, $resourceToSignRef) = @_;
-    debug("JMC3 resourceToSignRef = $$resourceToSignRef");
     for my $ep (@endpoints) {
-        debug("JMC ep = $ep");
         if ($host =~ /(.*)\.$ep/) { # vanity subdomain case
             my $vanityBucket = $1;
             $$resourceToSignRef = "/$vanityBucket".$$resourceToSignRef;

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -123,7 +123,7 @@ Usage $0 --id friendly-name (or AWSAccessKeyId) [options] -- [curl-options] [URL
   --createBucket [<region>]   create-bucket with optional location constraint
   --head                      HEAD request
   --debug                     enable debug logging
-  --sm                        sign the metadata in a metadata query (for ECS 3.0)
+  --sm                        do NOT sign the metadata in a metadata query (for ECS 3.0). Signing is the default
 
  common curl options:
   -H 'x-amz-acl: public-read' another way of using canned ACLs

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -36,6 +36,12 @@ my @endpoints = ( 's3.amazonaws.com',
                   's3-ap-northeast-1.amazonaws.com',
                   's3-sa-east-1.amazonaws.com', );
 
+my @resources = ("acl", "delete", "location", "logging", "notification",
+            "partNumber", "policy", "requestPayment", "response-cache-control",
+            "response-content-disposition", "response-content-encoding", "response-content-language",
+            "response-content-type", "response-expires", "torrent",
+            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore");
+
 my $CURL = "curl";
 
 # stop customizing here
@@ -58,6 +64,7 @@ my $copySourceObject;
 my $copySourceRange;
 my $postBody;
 my $calculateContentMD5 = 0;
+my $sm = 0;
 
 my $DOTFILENAME=".s3curl";
 my $EXECFILE=$FindBin::Bin;
@@ -98,6 +105,7 @@ GetOptions(
     'help' => \$help,
     'debug' => \$debug,
     'calculateContentMd5' => \$calculateContentMD5,
+    'sm' => \$sm,
 );
 
 my $usage = <<USAGE;
@@ -115,6 +123,8 @@ Usage $0 --id friendly-name (or AWSAccessKeyId) [options] -- [curl-options] [URL
   --createBucket [<region>]   create-bucket with optional location constraint
   --head                      HEAD request
   --debug                     enable debug logging
+  --sm                        sign the metadata in a metadata query (for ECS 3.0)
+
  common curl options:
   -H 'x-amz-acl: public-read' another way of using canned ACLs
   -v                          verbose logging
@@ -184,25 +194,31 @@ for (my $i=0; $i<@ARGV; $i++) {
         my $query = defined $4 ? $4 : "";
         debug("Found the url: host=$host; port=$port; uri=$requestURI; query=$query;");
         if (length $requestURI) {
+            debug("length is true requestURI = $requestURI");
             $resource = $requestURI;
         } else {
+            debug("length is false");
             $resource = "/";
         }
         my @attributes = ();
-        for my $attribute ("acl", "delete", "location", "logging", "notification",
-            "partNumber", "policy", "requestPayment", "response-cache-control",
-            "response-content-disposition", "response-content-encoding", "response-content-language",
-            "response-content-type", "response-expires", "torrent",
-            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore") {
+        #if the -sm command line option was used then this is probably a search metadata query
+        #and the query=xxx needs to be signed in ECS v3.0
+        if ($sm) {
+            push (@resources, "query");
+        }
+        for my $attribute (@resources) {
             if ($query =~ /(?:^|&)($attribute(?:=[^&]*)?)(?:&|$)/) {
                 push @attributes, uri_unescape($1);
             }
         }
         if (@attributes) {
+            debug("JMC there are attributes");
             $resource .= "?" . join("&", @attributes);
+            debug("JMC resource in attributes = $resource");
         }
         # handle virtual hosted requests
         getResourceToSign($host, \$resource);
+        debug("JMC1 resource = $resource");
     }
     elsif ($arg =~ /\-X/) {
         # mainly for DELETE
@@ -226,6 +242,7 @@ for (my $i=0; $i<@ARGV; $i++) {
     }
 }
 
+debug("JMC2 resource = $resource");
 die "Couldn't find resource by digging through your curl command line args!"
     unless defined $resource;
 
@@ -238,6 +255,14 @@ foreach (sort (keys %xamzHeaders)) {
 # NOTE: Need to skip the Date: header, in case x-amz-date got provided
 my $httpDate = (defined $xamzHeaders{'x-amz-date'}) ? '' : POSIX::strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime);
 my $stringToSign = "$method\n$contentMD5\n$contentType\n$httpDate\n$xamzHeadersToSign$resource";
+
+debug("JMC method = $method");
+debug("JMC contentMD5 = $contentMD5");
+debug("JMC contentType = $contentType");
+debug("JMC httpDate = $httpDate");
+debug("JMC xamzHeadersToSign = $xamzHeadersToSign");
+debug("JMC resource = $resource");
+debug("JMC ");
 
 debug("StringToSign='" . $stringToSign . "'");
 my $hmac = Digest::HMAC_SHA1->new($secretKey);
@@ -288,7 +313,9 @@ sub debug {
 
 sub getResourceToSign {
     my ($host, $resourceToSignRef) = @_;
+    debug("JMC3 resourceToSignRef = $$resourceToSignRef");
     for my $ep (@endpoints) {
+        debug("JMC ep = $ep");
         if ($host =~ /(.*)\.$ep/) { # vanity subdomain case
             my $vanityBucket = $1;
             $$resourceToSignRef = "/$vanityBucket".$$resourceToSignRef;


### PR DESCRIPTION
added -sm command line argument.
If -sm is used, the "query" attribute of a search metadata request will NOT be signed.
the default will sign the query attribute.
