### PR TITLE
s3curl.pl : Adding fanout to the list of signed parameters 

### DIFF
--- a/s3curl.pl
+++ b/s3curl.pl
@@ -193,7 +193,7 @@ for (my $i=0; $i<@ARGV; $i++) {
             "partNumber", "policy", "requestPayment", "response-cache-control",
             "response-content-disposition", "response-content-encoding", "response-content-language",
             "response-content-type", "response-expires", "torrent",
-            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata");
+            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout");
         for my $attribute (@signedAttributes) {
             if ($query =~ /(?:^|&)($attribute(?:=[^&]*)?)(?:&|$)/) {
                 push @attributes, uri_unescape($1);


### PR DESCRIPTION
As part of the DVR feature we need to have "fanout" sub-resource as part of the signed parameters for S3 requests.