### PR TITLE
Add changes related to get object attributes

### DIFF
--- a/s3curl.pl
+++ b/s3curl.pl
@@ -196,12 +196,19 @@ for (my $i=0; $i<@ARGV; $i++) {
             $resource = "/";
         }
         my @attributes = ();
+	my $query_param = 'query';
+        my $attributes_param='attributes';
         for my $attribute ("acl", "delete", "location", "logging", "notification",
             "partNumber", "policy", "requestPayment", "response-cache-control",
             "response-content-disposition", "response-content-encoding", "response-content-language",
             "response-content-type", "response-expires", "torrent",
-            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout") {
+            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout","attributes") {
             if ($query =~ /(?:^|&)($attribute)=?([^&]+)?(?:&|$)/) {
+		    if (grep($query_param,@attributes)){
+			    if($attribute==$attributes_param){
+				    next;
+			    }
+		    }
                 my $kv_pair = sprintf("%s%s", $1, $2 ? sprintf("=%s", $2) : '');
 
                 push @attributes, uri_unescape($kv_pair);

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -203,7 +203,7 @@ for (my $i=0; $i<@ARGV; $i++) {
             "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout", "attributes") {
             if ($query =~ /(?:^|&)($attribute)=?([^&]+)?(?:&|$)/) {
                 
-		# do not sign "attributes" parameter if this is a metadata query
+		# do not sign "attributes" parameter if this is a metadata search query
                 if ($attribute == "attributes" && grep("query", @attributes)) {
 		    next;
                 }        

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -202,12 +202,12 @@ for (my $i=0; $i<@ARGV; $i++) {
             "response-content-type", "response-expires", "torrent",
             "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout", "attributes") {
             if ($query =~ /(?:^|&)($attribute)=?([^&]+)?(?:&|$)/) {
-                
-		# do not sign "attributes" parameter if this is a metadata search query
+
+                # do not sign "attributes" parameter if this is a metadata search query
                 if ($attribute == "attributes" && grep("query", @attributes)) {
-		    next;
-                }        
-		my $kv_pair = sprintf("%s%s", $1, $2 ? sprintf("=%s", $2) : '');
+                    next;
+                }
+                my $kv_pair = sprintf("%s%s", $1, $2 ? sprintf("=%s", $2) : '');
 
                 push @attributes, uri_unescape($kv_pair);
             }

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -202,7 +202,7 @@ for (my $i=0; $i<@ARGV; $i++) {
             "partNumber", "policy", "requestPayment", "response-cache-control",
             "response-content-disposition", "response-content-encoding", "response-content-language",
             "response-content-type", "response-expires", "torrent",
-            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout","attributes") {
+            "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout", "attributes") {
             if ($query =~ /(?:^|&)($attribute)=?([^&]+)?(?:&|$)/) {
 		    if (grep($query_param,@attributes)){
 			    if($attribute==$attributes_param){

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -196,20 +196,18 @@ for (my $i=0; $i<@ARGV; $i++) {
             $resource = "/";
         }
         my @attributes = ();
-	my $query_param = 'query';
-        my $attributes_param='attributes';
         for my $attribute ("acl", "delete", "location", "logging", "notification",
             "partNumber", "policy", "requestPayment", "response-cache-control",
             "response-content-disposition", "response-content-encoding", "response-content-language",
             "response-content-type", "response-expires", "torrent",
             "uploadId", "uploads", "versionId", "versioning", "versions", "website", "lifecycle", "restore", "query", "searchmetadata", "fanout", "attributes") {
             if ($query =~ /(?:^|&)($attribute)=?([^&]+)?(?:&|$)/) {
-		    if (grep($query_param,@attributes)){
-			    if($attribute==$attributes_param){
-				    next;
-			    }
-		    }
-                my $kv_pair = sprintf("%s%s", $1, $2 ? sprintf("=%s", $2) : '');
+                
+		# do not sign "attributes" parameter if this is a metadata query
+                if ($attribute == "attributes" and grep("query", @attributes) {
+		    next;
+                }        
+		my $kv_pair = sprintf("%s%s", $1, $2 ? sprintf("=%s", $2) : '');
 
                 push @attributes, uri_unescape($kv_pair);
             }

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -204,7 +204,7 @@ for (my $i=0; $i<@ARGV; $i++) {
             if ($query =~ /(?:^|&)($attribute)=?([^&]+)?(?:&|$)/) {
                 
 		# do not sign "attributes" parameter if this is a metadata query
-                if ($attribute == "attributes" and grep("query", @attributes) {
+                if ($attribute == "attributes" && grep("query", @attributes)) {
 		    next;
                 }        
 		my $kv_pair = sprintf("%s%s", $1, $2 ? sprintf("=%s", $2) : '');


### PR DESCRIPTION
In the MetadataSearch API, both 'query' and 'attributes' parameters are passed in the query parameters of request. However, only 'query' param was originally included in the string-to-sign
for MetadataSearch  API

Later, with the introduction of the GetObjectAttributes API, the attributes parameter was added to the list of signed parameters to support its functionality. As a result, 'attributes' also began to be included in the string-to-sign for  MetadataSearc API 

This change led to signature mismatch errors in MetadataSearch API requests, since the client was not signing the 'attributes' parameter, while the server was expecting it.

To resolve this, a conditional logic was implemented on the server side to exclude 'attributes' from the string-to-sign specifically for MetadataSearch API requests.

This fix also requires corresponding changes on the client side, including:

The S3 curl client, which must avoid signing the attributes parameter for MetadataSearch requests.
The test suite client, which must be updated to reflect this logic and ensure correct signing behavior across test cases.


Testing steps :

ip=10.249.245.141
id=wuser1@sanity.local
key=RWT2tzB7+ok0k9lyq4cLKFFLHYziJEqqKNIJmj/j
bucket=smitabucket


##Create bucket with metadata search on
./s3curl.pl --ord --id=$id --key=$key --endpoint $ip --createbucket --  http://$ip:9020/$bucket  -H 'x-emc-metadata-search:x-amz-meta-location;String' -v

##Add object
./s3curl.pl  --debug --ord --id=$id --key=$key --endpoint $ip  --put 3g.txt -- -H 'x-amz-meta-location:NewYork' http://$ip:9020/$bucket/objn3 -v

##Meta data query
./s3curl.pl --ord --id=$id --key=$key --endpoint $ip --debug  --get --  "http://$ip:9020/$bucket?query=x-amz-meta-location==NewYork&attributes=ALL_SMD"  |xmllint --format -


##Get object attributes
./s3curl.pl  --debug --ord --id=$id --key=$key --endpoint $ip --get -- -H 'x-amz-object-attributes:StorageClass' http://$ip:9020/$bucket/objn3?attributes -v